### PR TITLE
Use Functors instead of Flux

### DIFF
--- a/src/TopoChains.jl
+++ b/src/TopoChains.jl
@@ -1,6 +1,6 @@
 module TopoChains
 
-using Requires
+using Functors
 
 export FuncTopo, @functopo_str, @functopo
 export TopoChain
@@ -9,9 +9,6 @@ include("code.jl")
 include("topology.jl")
 include("topochain.jl")
 
-function __init__()
-    @require Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c" begin
-        Flux.functor(s::TopoChain) = s.models, m -> TopoChain(s.topo, m...)
-    end
-end
+Functors.functor(s::TopoChain) = s.models, m -> TopoChain(s.topo, m...)
+
 end


### PR DESCRIPTION
Opening this as an (incomplete) PR since I can't file an issue:

Flux re-exports `functor`, `@functor` and many related functions from https://github.com/FluxML/Functors.jl. Thus, this package can simply rely on the lightweight subpackage instead of having to pull in `Requires` (which, yes, should still come with a compat entry) for Flux.